### PR TITLE
nix-serve: depend on nix.perl-bindings

### DIFF
--- a/modules/pkgs/nix-serve/default.nix
+++ b/modules/pkgs/nix-serve/default.nix
@@ -10,7 +10,7 @@ in stdenv.mkDerivation {
 
   src = "${./nix-serve.psgi}";
 
-  buildInputs = [ pxz perl nix ]
+  buildInputs = [ pxz perl nix nix.perl-bindings ]
     ++ (with perlPackages; [ DBI DBDSQLite Plack Starman ]);
 
   phases = [ "installPhase" ];


### PR DESCRIPTION
This is necessary for Nix 2.0